### PR TITLE
Update to use "json" for the session post command

### DIFF
--- a/ElvantoAPI/__init__.py
+++ b/ElvantoAPI/__init__.py
@@ -135,7 +135,7 @@ class Connection():
         """
         global api_url
         posturl = api_url + endpoint + ("" if endpoint[:-1] == "." else ".") + "json"
-        self.data = self.s.post(posturl, data=kwargs) #This is the code that does the actual call
+        self.data = self.s.post(posturl, json=kwargs) #This is the code that does the actual call
         info = json.loads(self.data.text)
         if info["status"] != "ok":
             if int(info["error"]["code"]) == 121: #Token Expired


### PR DESCRIPTION
As discussed in #4 , here is a PR with the change from "data" to "json" for the session post command. I have tested this with the following API calls:

```
connection._Post("services/getInfo", id=id, fields=['songs', 'volunteers'])

connection._Post("people/search", search={"firstname":"Nn", "volunteer":"Yes"}, fields=["birthday","home_address"])
```

Both these calls work as expected after the change to "json", but maybe you would like to do some more tests to make sure nothing else is affected by the change?

Here is some more info on "data" vs "json", [StackOverflow](https://stackoverflow.com/questions/9733638/post-json-using-python-requests?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa)